### PR TITLE
fix: improve retry handling and PR creation robustness

### DIFF
--- a/internal/orchestrator/polling.go
+++ b/internal/orchestrator/polling.go
@@ -214,6 +214,17 @@ func (d *Daemon) filterPendingIssues(ctx context.Context, issues []issueInfo) []
 			}
 		}
 
+		// Skip failed issues unless retry was requested
+		if st.CurrentPhase == state.PhaseFailed {
+			if d.orchestrator.CheckForRetry(ctx, info.repo, info.issue, st) {
+				d.logger.Printf("Retry requested for issue #%d", info.issue.Number)
+				// State was updated by CheckForRetry, continue to process
+			} else {
+				// Skip - failed and no retry requested
+				continue
+			}
+		}
+
 		// Store state in our tracking map
 		d.allStatesMu.Lock()
 		if d.allStates[info.repo] == nil {

--- a/internal/workflow/pr.go
+++ b/internal/workflow/pr.go
@@ -3,6 +3,9 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/anthropics/ultra-engineer/internal/claude"
@@ -28,6 +31,11 @@ type PRResult struct {
 
 // CreatePR creates a pull request from the implementation
 func (p *PRPhase) CreatePR(ctx context.Context, repo string, issue *providers.Issue, headBranch, baseBranch, repoDir string) (*PRResult, error) {
+	// Ensure the branch is pushed to remote before creating PR
+	if err := p.ensureBranchPushed(repoDir, headBranch); err != nil {
+		return nil, fmt.Errorf("failed to push branch: %w", err)
+	}
+
 	// Generate summary of changes using Claude
 	summary, err := p.GenerateChangeSummary(ctx, repoDir, baseBranch, headBranch)
 	if err != nil {
@@ -45,10 +53,53 @@ func (p *PRPhase) CreatePR(ctx context.Context, repo string, issue *providers.Is
 		IssueID: issue.Number,
 	})
 	if err != nil {
+		// Check if PR already exists for this branch - try to find and return it
+		if existingPR := p.findExistingPR(ctx, repo, err); existingPR != nil {
+			return &PRResult{PR: existingPR}, nil
+		}
 		return nil, err
 	}
 
 	return &PRResult{PR: pr}, nil
+}
+
+// findExistingPR extracts PR number from "already exists" error and returns the PR
+func (p *PRPhase) findExistingPR(ctx context.Context, repo string, err error) *providers.PR {
+	errStr := err.Error()
+	if !strings.Contains(errStr, "already exists") {
+		return nil
+	}
+
+	// Extract PR number from URL like "https://github.com/owner/repo/pull/123"
+	re := regexp.MustCompile(`/pull/(\d+)`)
+	matches := re.FindStringSubmatch(errStr)
+	if len(matches) < 2 {
+		return nil
+	}
+
+	prNum, parseErr := strconv.Atoi(matches[1])
+	if parseErr != nil {
+		return nil
+	}
+
+	pr, getErr := p.provider.GetPR(ctx, repo, prNum)
+	if getErr != nil {
+		return nil
+	}
+
+	return pr
+}
+
+// ensureBranchPushed ensures the branch is pushed to the remote
+// This handles cases where the remote branch was deleted (e.g., after closing a PR)
+func (p *PRPhase) ensureBranchPushed(repoDir, branch string) error {
+	cmd := exec.Command("git", "push", "-u", "origin", branch, "--force-with-lease")
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git push failed: %w\nOutput: %s", err, string(output))
+	}
+	return nil
 }
 
 func (p *PRPhase) formatPRBody(issue *providers.Issue, summary string) string {


### PR DESCRIPTION
## Summary

Fixes several bugs discovered during daemon testing:

- **CheckForRetry now works for any failed issue** - Previously only checked issues with `needs-manual-resolution` label (merge conflicts only). Now checks any issue in `PhaseFailed` state.
- **Persist state changes on retry** - When `/retry` is detected, the updated state is now saved to a comment so subsequent reloads see the correct phase.
- **Push branch before PR creation** - Handles cases where the remote branch was deleted (e.g., after closing a previous PR)
- **Handle "PR already exists" errors** - Finds and returns the existing PR instead of failing

## Test plan

- [x] Tested by processing issue #1 through the daemon
- [x] Verified PR #4 was created and merged successfully
- [x] Linter passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)