### PR TITLE
Implement: Issues before use

### DIFF
--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -74,6 +74,9 @@ type Provider interface {
 	Clone(ctx context.Context, repo string, dest string) error
 	GetDefaultBranch(ctx context.Context, repo string) (string, error)
 
+	// Authorization
+	IsCollaborator(ctx context.Context, repo, username string) (bool, error)
+
 	// Provider info
 	Name() string
 }

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -1,0 +1,36 @@
+package security
+
+import (
+	"context"
+	"log"
+
+	"github.com/anthropics/ultra-engineer/internal/providers"
+)
+
+// IsAuthorized checks if a comment author is authorized to interact with the workflow.
+// Only repository collaborators with sufficient permissions (admin, maintain, write, triage)
+// are authorized. Non-collaborators cannot interact, even if they created the issue.
+//
+// If IsCollaborator returns an error, it is logged and the function returns false, nil
+// (fail closed). This prevents transient API errors from causing workflow failures while
+// still denying access when authorization cannot be verified.
+func IsAuthorized(ctx context.Context, provider providers.Provider, repo, commentAuthor string, logger *log.Logger) (bool, error) {
+	isCollab, err := provider.IsCollaborator(ctx, repo, commentAuthor)
+	if err != nil {
+		// Log the error for debugging but fail closed
+		if logger != nil {
+			logger.Printf("Authorization check failed for user %s on %s: %v (treating as unauthorized)", commentAuthor, repo, err)
+		}
+		return false, nil
+	}
+
+	if !isCollab {
+		// Log unauthorized attempts for security monitoring
+		if logger != nil {
+			logger.Printf("Unauthorized access attempt: user %s is not a collaborator on %s", commentAuthor, repo)
+		}
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/internal/security/auth_test.go
+++ b/internal/security/auth_test.go
@@ -1,0 +1,99 @@
+package security
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"testing"
+
+	"github.com/anthropics/ultra-engineer/internal/providers"
+)
+
+func TestIsAuthorized_CollaboratorIsAuthorized(t *testing.T) {
+	mock := providers.NewMockProvider()
+	mock.SetCollaborator("owner/repo", "collaborator", true)
+
+	logger := log.New(&bytes.Buffer{}, "", 0)
+
+	authorized, err := IsAuthorized(context.Background(), mock, "owner/repo", "collaborator", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !authorized {
+		t.Error("expected collaborator to be authorized")
+	}
+}
+
+func TestIsAuthorized_NonCollaboratorIsNotAuthorized(t *testing.T) {
+	mock := providers.NewMockProvider()
+	// Don't set the user as collaborator - default is false
+
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	authorized, err := IsAuthorized(context.Background(), mock, "owner/repo", "outsider", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if authorized {
+		t.Error("expected non-collaborator to not be authorized")
+	}
+
+	// Check that the unauthorized attempt was logged
+	logOutput := logBuf.String()
+	if logOutput == "" {
+		t.Error("expected unauthorized attempt to be logged")
+	}
+}
+
+func TestIsAuthorized_IssueAuthorWhoIsNotCollaboratorIsNotAuthorized(t *testing.T) {
+	mock := providers.NewMockProvider()
+	// Add an issue created by "issueAuthor" who is NOT a collaborator
+	mock.AddIssue("owner/repo", &providers.Issue{
+		Number: 1,
+		Title:  "Test Issue",
+		Author: "issueAuthor",
+	})
+	// Explicitly set issueAuthor as NOT a collaborator
+	mock.SetCollaborator("owner/repo", "issueAuthor", false)
+
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	authorized, err := IsAuthorized(context.Background(), mock, "owner/repo", "issueAuthor", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if authorized {
+		t.Error("expected issue author who is not a collaborator to not be authorized")
+	}
+}
+
+func TestIsAuthorized_NilLoggerDoesNotPanic(t *testing.T) {
+	mock := providers.NewMockProvider()
+	// Don't set as collaborator - should log but not panic with nil logger
+
+	authorized, err := IsAuthorized(context.Background(), mock, "owner/repo", "user", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if authorized {
+		t.Error("expected unauthorized with nil logger")
+	}
+}
+
+func TestIsAuthorized_ExplicitlySetCollaboratorFalse(t *testing.T) {
+	mock := providers.NewMockProvider()
+	// Explicitly set user as NOT a collaborator
+	mock.SetCollaborator("owner/repo", "user", false)
+
+	logger := log.New(&bytes.Buffer{}, "", 0)
+
+	authorized, err := IsAuthorized(context.Background(), mock, "owner/repo", "user", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if authorized {
+		t.Error("expected user explicitly set as non-collaborator to not be authorized")
+	}
+}


### PR DESCRIPTION
## Summary
Adds collaborator-only authorization to prevent non-collaborators from interacting with the workflow (answering questions, approving plans, providing PR feedback, or triggering retries).

## Changes
- `internal/providers/provider.go` - Added `IsCollaborator` method to the Provider interface
- `internal/providers/github.go` - Implemented `IsCollaborator` using the GitHub API permissions endpoint; authorizes users with admin, maintain, write, or triage permissions
- `internal/providers/gitea.go` - Implemented `IsCollaborator` using the Gitea collaborators API with retry support
- `internal/providers/mock.go` - Added `Collaborators` map and helper methods for testing authorization
- `internal/security/auth.go` - New package with `IsAuthorized` function that checks collaborator status and fails closed on API errors
- `internal/security/auth_test.go` - Unit tests for authorization logic including edge cases
- `internal/orchestrator/orchestrator.go` - Added authorization checks in `handleQuestions`, `handleApproval`, `handleReview`, and `CheckForRetry` to skip unauthorized users

## Notes
- Fails closed: if the collaborator API check fails, the user is treated as unauthorized (logged for debugging)
- Read-only repository members are explicitly excluded from authorization
- Unauthorized attempts are logged for security monitoring

Closes #6

---
*Automated by Ultra Engineer*
