### PR TITLE
fix: treat merge-not-allowed as temporary and retry instead of failing

### DIFF
--- a/internal/providers/gitea.go
+++ b/internal/providers/gitea.go
@@ -472,6 +472,15 @@ func (g *GiteaProvider) MergePR(ctx context.Context, repo string, number int) er
 	_, err := g.doRequest(ctx, "POST", path, map[string]string{
 		"do": "squash", // Use squash to avoid duplicate commits
 	})
+	if err != nil {
+		errStr := strings.ToLower(err.Error())
+		// Gitea returns 405 or 409 when merge is not allowed yet (e.g. pending
+		// required approvals, unresolved reviews, branch protection rules).
+		if strings.Contains(errStr, "405") || strings.Contains(errStr, "409") ||
+			strings.Contains(errStr, "not allowed") {
+			return fmt.Errorf("%w: %v", ErrMergeNotAllowed, err)
+		}
+	}
 	return err
 }
 

--- a/internal/providers/github.go
+++ b/internal/providers/github.go
@@ -375,6 +375,13 @@ func (g *GitHubProvider) GetPRReviewComments(ctx context.Context, repo string, n
 
 func (g *GitHubProvider) MergePR(ctx context.Context, repo string, number int) error {
 	_, err := g.runGH(ctx, "pr", "merge", strconv.Itoa(number), "--repo", repo, "--merge", "--delete-branch")
+	if err != nil {
+		errStr := strings.ToLower(err.Error())
+		if strings.Contains(errStr, "not allowed") || strings.Contains(errStr, "merge not allowed") ||
+			strings.Contains(errStr, "required status check") || strings.Contains(errStr, "review is required") {
+			return fmt.Errorf("%w: %v", ErrMergeNotAllowed, err)
+		}
+	}
 	return err
 }
 

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -2,8 +2,14 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrMergeNotAllowed is returned when a PR cannot be merged yet (e.g. pending
+// required approvals, branch protection rules, etc.). Callers should treat
+// this as a temporary condition and retry later rather than failing permanently.
+var ErrMergeNotAllowed = errors.New("merge not allowed")
 
 // Issue represents an issue from any provider
 type Issue struct {


### PR DESCRIPTION
Gitea returns 405/409 when a PR can't be merged yet (e.g. pending required approvals, branch protection rules). Previously this caused a permanent failure. Now the orchestrator waits and retries on the next poll cycle.